### PR TITLE
Fix github actions to use lowercased RepoOwner name

### DIFF
--- a/.github/workflows/build_and_push.yaml
+++ b/.github/workflows/build_and_push.yaml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - id: RepoOwnerToLowerCase
+        run: INPUT=${{ github.repository_owner }} echo "::set-output name=repoOwner::${INPUT,,}"
 
       - name: Get latest VoiceCraft version
         id: voicecraft
@@ -56,5 +59,5 @@ jobs:
           tags: |
             ${{ vars.DOCKERHUB_USERNAME }}/voicecraft:latest
             ${{ vars.DOCKERHUB_USERNAME }}/voicecraft:${{ steps.voicecraft.outputs.release }}
-            ghcr.io/${{ github.repository_owner }}/voicecraft:latest
-            ghcr.io/${{ github.repository_owner }}/voicecraft:${{ steps.voicecraft.outputs.release }}
+            ghcr.io/${{ steps.RepoOwnerToLowerCase.outputs.repoOwner }}/voicecraft:latest
+            ghcr.io/${{ steps.RepoOwnerToLowerCase.outputs.repoOwner }}/voicecraft:${{ steps.voicecraft.outputs.release }}


### PR DESCRIPTION
Fix github actions to use lowercased RepoOwner name
+ using checkout@v4